### PR TITLE
fixed error of incorrect number of dimensions

### DIFF
--- a/R/wrf_raster.R
+++ b/R/wrf_raster.R
@@ -74,8 +74,8 @@ wrf_raster <- function(file = file.choose(),
   ncols <- dim(inNCLon)[1]
 
   # Reverse column order to get UL in UL
-  x <- as.vector(inNCLon[,ncol(inNCLon):1])
-  y <- as.vector(inNCLat[,ncol(inNCLat):1])
+  x <- as.vector(inNCLon[ncol(inNCLon):1])
+  y <- as.vector(inNCLat[ncol(inNCLat):1])
 
   coords <- as.matrix(cbind(x, y))
 


### PR DESCRIPTION
I got the below error when I used the wrf_raster function.

> Error in inNCLon[, ncol(inNCLon):1] : incorrect number of dimensions

I fixed the error, by removing commas.

 