### PR TITLE
add support for Equidistant Cylindrical projection

### DIFF
--- a/R/wrf_raster.R
+++ b/R/wrf_raster.R
@@ -102,7 +102,10 @@ wrf_raster <- function(file = file.choose(),
                           " +lat_0=", cen_lat,
                           " +lon_0=", cen_lon,
                           " +x_0=0 +y_0=0 +a=6370000 +b=6370000 +units=m +no_defs")
-  } else {
+  } else if(map_proj == 6){
+    geogrd.proj <- paste0("+proj=eqc +lat_ts=",0, 
+                          " +lat_0=",cen_lat, " +lon_0=",cen_lon, " +x_0=",0, " +y_0=",0," +ellps=WGS84 +units=m")
+  }else {
     stop('Error: Projection type not supported (currently this tool only works for Lambert Conformal Conic projections).') # nocov
   }
 


### PR DESCRIPTION
Hello @Schuch666, I am working on lat-long projection too, so I added this to wrf_raster. I tested the results and it seems to be working fine. You can see the images below.

![image](https://user-images.githubusercontent.com/22841746/123855624-cad7ed80-d928-11eb-9691-4a8aea31fbf4.png)
Height variable from wrf_raster

![image](https://user-images.githubusercontent.com/22841746/123855666-d3c8bf00-d928-11eb-9d2c-1ff03ccfacd4.png)
WRF Domain from GIS4WRF

